### PR TITLE
Fix ConcurrentModificationException on autoMessagesClone

### DIFF
--- a/src/main/java/com/github/groundbreakingmc/gigachat/GigaChat.java
+++ b/src/main/java/com/github/groundbreakingmc/gigachat/GigaChat.java
@@ -134,6 +134,7 @@ public final class GigaChat extends JavaPlugin {
     @Override
     public void onDisable() {
         this.database.closeConnection();
+        this.autoMessages.shutdown();
         super.getServer().getScheduler().cancelTasks(this);
     }
 

--- a/src/main/java/com/github/groundbreakingmc/gigachat/commands/main/arguments/ReloadArgument.java
+++ b/src/main/java/com/github/groundbreakingmc/gigachat/commands/main/arguments/ReloadArgument.java
@@ -35,7 +35,6 @@ public final class ReloadArgument extends Argument {
 
     private void reloadAll() {
         super.getPlugin().getAutoMessages().cancel();
-        super.getPlugin().getAutoMessages().clearClonedAutoMessages();
         super.getPlugin().reloadConfig();
         super.getPlugin().setupConfigValues();
         super.getPlugin().getCooldownCollections().setCooldowns();
@@ -46,7 +45,6 @@ public final class ReloadArgument extends Argument {
         for (final String arg : ImmutableSet.copyOf(args)) { // ImmutableSet needs to remove all duplicates
             if (arg.equalsIgnoreCase("auto-messages")) {
                 super.getPlugin().getAutoMessages().cancel();
-                super.getPlugin().getAutoMessages().clearClonedAutoMessages();
                 super.getPlugin().getAutoMessagesValues().setValues();
                 super.getPlugin().getAutoMessages().run();
             }


### PR DESCRIPTION
autoMessagesClone may throw a ConcurrentModificationException if task is delayed (or the user has set the interval too often)